### PR TITLE
Modernize

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,12 @@
 Package: cardinalscripts
 Title: Short Scripts for Cardinal MSI
-Version: 0.2.0
-Authors@R: person("Gordon", "Luu", email="gluu2@uic.edu", role=c("aut", "cre"))
+Version: 0.3.0
+Authors@R: person("Gordon", "Luu", email="gtluu912@gmail.com", role=c("aut", "cre"))
 Description: A collection of short scripts to be used short scripts to help streamline imaging mass spectrometry analysis in the R package Cardinal.
-Depends: R (>= 3.6)
-Imports: Cardinal, stringr, fuzzyjoin, dplyr, ggplot2, reticulate
+Depends: R (>= 4.3.1)
+Imports:
+    Cardinal (>= 3.4.1),
+	stringr(>= 1.5.0),
+	fuzzyjoin (>= 0.1.6),
+	dplyr (>= 1.1.3),
+	ggplot2 (>= 3.4.4)

--- a/R/getStatisticTable.R
+++ b/R/getStatisticTable.R
@@ -16,7 +16,7 @@
 #' 
 #' sscParams <- optimizeSSCParams(ssc, r=rparam, k=kparam, s=sparam)
 #' 
-#' getStatisticTable(ssc, sscParams)
+#' getStatisticTable(ssc, sscParams$params)
 #' 
 #' @export
 getStatisticTable <- function(sscObject, sscParams) {

--- a/R/sscImageReport.R
+++ b/R/sscImageReport.R
@@ -9,14 +9,18 @@
 #' @return \code{NULL}; a PDF file will be in the specified location.
 #' @example 
 #' 
-#' sscImageReport(processedData, filename='three_images')
+#' sscImageReport(ssc, filename='three_images')
 #' 
-#' sscImageReport(processedData, filename='three_images', layout=c(2, 2), xlim=c(0, 300), ylim=c(0, 150))
+#' sscImageReport(ssc, filename='three_images', layout=c(2, 2), xlim=c(0, 300), ylim=c(0, 150))
 #'
 #' @export
 sscImageReport <- function(ssc, filedir=getwd(), filename, ...) {
-  pdf(paste0(filename, '.pdf'))
-  for (i in nrow(modelData(ssc))) {
+  pdf(paste0(filedir, '/', filename, '.pdf'))
+  for (i in 1:nrow(modelData(ssc))) {
+    print(paste0('Saving SSC image for',
+                 ' r=', as.character(modelData(ssc)[i,]$r),
+                 ' k=', as.character(modelData(ssc)[i,]$k),
+                 ' s=', as.character(modelData(ssc)[i,]$s)))
     print(image(ssc, model=as.list(modelData(ssc)[i,]), ...))
   }
   dev.off()

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ devtools::load_all("/path/to/cardinalscripts")
 ```
 
 ## Dependencies
-R (>= 4.3.1)
-Cardinal (>= 3.4.1)
-stringr(>= 1.5.0)
-fuzzyjoin (>= 0.1.6)
-dplyr (>= 1.1.3)
-ggplot2 (>= 3.4.4)
+- R (>= 4.3.1)
+- Cardinal (>= 3.4.1)
+- stringr(>= 1.5.0)
+- fuzzyjoin (>= 0.1.6)
+- dplyr (>= 1.1.3)
+- ggplot2 (>= 3.4.4)
 
 ## Usage
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-- add documentation for sscImageReport
-- add documentation for ionImageReport
-- add options for ... params


### PR DESCRIPTION
- use native R implementation of kneedle
- no longer requires ```reticulate``` or ```numpy```
- deprecate wrapper functions written for Cardinal 2.4.0
- update documentation
- min versions for dependencies